### PR TITLE
Fix clicking on ACTION messages

### DIFF
--- a/ui/buffers.go
+++ b/ui/buffers.go
@@ -1248,6 +1248,13 @@ func (bs *BufferList) DrawTimeline(ui *UI, x0, y0, nickColWidth int) {
 			xb, xe := printIdent(vx, x0+7, yi, nickColWidth, Styled(line.Head, identSt))
 
 			if !strings.HasSuffix(line.Head, "--") && !strings.HasSuffix(line.Head, "!!") {
+				nick := line.Head
+				if nick == "*" {
+					// set actual nick of ACTION message within line content
+					nick = line.Body.string[:strings.Index(line.Body.string, " ")]
+					xb = x1
+					xe = xb + len(nick)
+				}
 				ui.clickEvents = append(ui.clickEvents, clickEvent{
 					xb: xb,
 					xe: xe,
@@ -1257,7 +1264,7 @@ func (bs *BufferList) DrawTimeline(ui *UI, x0, y0, nickColWidth int) {
 							NetID:  b.netID,
 							Buffer: b.title,
 						},
-						Nick: line.Head,
+						Nick: nick,
 					},
 				})
 			}


### PR DESCRIPTION
Clicking the nick on a user message that is an ACTION, which is `*`, will open the buffer for `*`, which is an invalid user. This patch fixes this issue by opening the actual nick of the user who sent the ACTION message. Performance implications unknown.

Alternative to this patch:
```diff
diff --git a/ui/buffers.go b/ui/buffers.go
index 2a1943e..8713db6 100644
--- a/ui/buffers.go
+++ b/ui/buffers.go
@@ -1247,7 +1247,7 @@ func (bs *BufferList) DrawTimeline(ui *UI, x0, y0, nickColWidth int) {
                        }
                        xb, xe := printIdent(vx, x0+7, yi, nickColWidth, Styled(line.Head, identSt))
 
-                       if !strings.HasSuffix(line.Head, "--") && !strings.HasSuffix(line.Head, "!!") {
+                       if !strings.HasSuffix(line.Head, "--") && !strings.HasSuffix(line.Head, "!!") && line.Head != "*" {
                                ui.clickEvents = append(ui.clickEvents, clickEvent{
                                        xb: xb,
                                        xe: xe,
-- 
2.51.0

```